### PR TITLE
Fix minimal WebGL test page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>WebGL Test</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r160/three.min.js"></script>
     <style>
-        body { margin: 0; padding: 0; }
-        canvas { display: block; }
         html, body {
-            overflow: hidden;
+            margin: 0;
+            padding: 0;
             height: 100%;
+            overflow: hidden;
         }
+        canvas { display: block; }
     </style>
 </head>
 <body>
     <script src="main.js" defer></script>
 </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -4,12 +4,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Camera Setup
     const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-    camera.position.z = 5;
+    camera.position.set(0, 0, 5);
+    camera.lookAt(0, 0, 0);
 
     // Renderer Setup
     const renderer = new THREE.WebGLRenderer({ antialias: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setClearColor(0x000000);
     document.body.appendChild(renderer.domElement);
+
+    function onWindowResize() {
+        camera.aspect = window.innerWidth / window.innerHeight;
+        camera.updateProjectionMatrix();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+    }
+    window.addEventListener('resize', onWindowResize);
 
     // Player Ship Creation
     let ship;


### PR DESCRIPTION
## Summary
- add standard HTML document structure
- set background color and resizing support
- adjust camera to look at the origin

## Testing
- `node -e "console.log('Node is working')"`


------
https://chatgpt.com/codex/tasks/task_e_683f88728004832fadcd3d629deb9a27